### PR TITLE
Feature/include school name and academic year in login response

### DIFF
--- a/src/app/Http/Controllers/Api/AuthController.php
+++ b/src/app/Http/Controllers/Api/AuthController.php
@@ -7,7 +7,6 @@ use App\Constants\HttpStatus as STATUS;
 use App\Http\Requests\Api\Auth\LoginRequest;
 use App\Http\Resources\User\UserWithRelatedInfoResource;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 
 class AuthController extends ApiController
 {
@@ -21,17 +20,15 @@ class AuthController extends ApiController
             $user = Auth::user();
             optional($user->userProfile);
             $tokenResult = $user->createToken('UserToken');
-            $accessToken = $tokenResult->accessToken;
-            $expiry = $tokenResult->token->expires_at;
 
             return $this->response(
                 statusCode: STATUS::HTTP_OK,
                 message: API_MSG::AUTHENTICATION_SUCCESS,
-                data: [
-                    'user' => new UserWithRelatedInfoResource($user),
-                    'access_token' => $accessToken,
-                    'token_expiry' => $expiry,
-                ]
+                data: array_merge(
+                    (new UserWithRelatedInfoResource($user))->resolve(),
+                    ['access_token' => $tokenResult->accessToken,
+                        'token_expiry' => $tokenResult->token->expires_at, ]
+                )
             );
         } else {
             return $this->errorResponse(

--- a/src/app/Http/Resources/User/UserWithRelatedInfoResource.php
+++ b/src/app/Http/Resources/User/UserWithRelatedInfoResource.php
@@ -18,25 +18,12 @@ class UserWithRelatedInfoResource extends JsonResource
             'id' => $this->id,
             'login_type' => $this->getRoleNames()->first(),
             'login_id' => $this->getLoginId(),
+            'email' => $this->email,
             'first_name' => $this->userProfile->first_name,
             'last_name' => $this->userProfile->last_name,
-            'email' => $this->email,
-            'email_verified_at' => $this->email_verified_at,
-            'birth_date' => optional($this->userProfile)->birth_date,
-            'gender' => optional($this->userProfile)->gender,
             'role' => $this->getRoleNames()->first(),
+            'school_name' => $this->getCurrentAcademicYear()->school->short_name,
+            'academic_year' => $this->getCurrentAcademicYear()->name,
         ];
-    }
-
-    /**
-     * Get the login ID based on user type (teacher or student).
-     */
-    protected function getLoginId(): ?string
-    {
-        return match ($this->getRoleNames()->first()) {
-            'teacher' => $this->teacher?->id,
-            'student' => $this->student?->id,
-            default => null
-        };
     }
 }

--- a/src/app/Models/AcademicYear.php
+++ b/src/app/Models/AcademicYear.php
@@ -4,10 +4,16 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class AcademicYear extends Model
 {
     use HasFactory;
 
     protected $fillable = ['name', 'start', 'end'];
+
+    public function school(): BelongsTo
+    {
+        return $this->belongsTo(School::class, 'school_id', 'id');
+    }
 }

--- a/src/app/Models/School.php
+++ b/src/app/Models/School.php
@@ -4,8 +4,14 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class School extends Model
 {
     use HasFactory;
+
+    public function academicYears(): HasMany
+    {
+        return $this->hasMany(AcademicYear::class, 'academic_year_id', 'id');
+    }
 }

--- a/src/app/Models/Student.php
+++ b/src/app/Models/Student.php
@@ -2,14 +2,18 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Student extends Model
 {
     use HasFactory;
-    use HasUuids;
 
     protected $fillable = ['user_id', 'student_no'];
+
+    public function academicYears(): BelongsToMany
+    {
+        return $this->belongsToMany(AcademicYear::class, 'student_year', 'student_id', 'academic_year_id');
+    }
 }

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -14,7 +14,7 @@ use Illuminate\Notifications\Notifiable;
 use Laravel\Passport\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
 
-class User extends Authenticatable implements HasName, FilamentUser
+class User extends Authenticatable implements FilamentUser, HasName
 {
     use HasApiTokens, HasFactory, HasRoles, Notifiable;
 
@@ -62,7 +62,33 @@ class User extends Authenticatable implements HasName, FilamentUser
     {
         return $this->hasOne(Student::class);
     }
-  
+
+    public function getLoginId(): ?string
+    {
+        $role = $this->getRoleNames()->first();
+
+        return match ($role) {
+            RoleEnum::TEACHER->value => $this->teacher?->id,
+            RoleEnum::STUDENT->value => $this->student?->id,
+            default => null
+        };
+    }
+
+    public function getCurrentAcademicYear(): ?AcademicYear
+    {
+        $role = $this->getRoleNames()->first();
+
+        return match ($role) {
+            RoleEnum::TEACHER->value => $this->teacher?->academicYears()
+                ->latest('created_at')
+                ->first(),
+            RoleEnum::STUDENT->value => $this->student?->academicYears()
+                ->latest('created_at')
+                ->first(),
+            default => null
+        };
+    }
+
     public function getFilamentName(): string
     {
         return 'Admin';

--- a/src/database/factories/StudentFactory.php
+++ b/src/database/factories/StudentFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Student>
+ */
+class StudentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'student_no' => fake()->creditCardNumber(),
+        ];
+    }
+}

--- a/src/database/migrations/2023_10_27_095809_create_schools_table.php
+++ b/src/database/migrations/2023_10_27_095809_create_schools_table.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Enums\SchoolStatus;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use App\Enums\SchoolStatus;
 
 return new class extends Migration
 {
@@ -15,13 +15,14 @@ return new class extends Migration
         Schema::create('schools', function (Blueprint $table) {
             $table->id();
             $table->text('name');
+            $table->string('short_name');
             $table->text('address')->nullable();
             $table->text('phone')->nullable();
             $table->text('mobile')->nullable();
             $table->text('email')->nullable();
             $table->text('website')->nullable();
             $table->text('logo')->nullable();
-            $table->enum('status', array_column(SchoolStatus::cases(),'value'))->default(SchoolStatus::INQUIRED);
+            $table->enum('status', array_column(SchoolStatus::cases(), 'value'))->default(SchoolStatus::INQUIRED);
             $table->timestamps();
         });
     }

--- a/src/database/migrations/2024_11_02_172659_create_student_year_table.php
+++ b/src/database/migrations/2024_11_02_172659_create_student_year_table.php
@@ -1,6 +1,7 @@
 <?php
 
-use App\Models\User;
+use App\Models\AcademicYear;
+use App\Models\Student;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -12,10 +13,9 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('students', function (Blueprint $table) {
-            $table->id();
-            $table->foreignIdFor(User::class, 'user_id');
-            $table->string('student_no');
+        Schema::create('student_year', function (Blueprint $table) {
+            $table->foreignIdFor(Student::class, 'student_id');
+            $table->foreignIdFor(AcademicYear::class, 'academic_year_id');
             $table->timestamps();
         });
     }
@@ -25,6 +25,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('students');
+        Schema::dropIfExists('student_year');
     }
 };

--- a/src/database/seeders/AcademicYearSeeder.php
+++ b/src/database/seeders/AcademicYearSeeder.php
@@ -15,7 +15,8 @@ class AcademicYearSeeder extends Seeder
     public function run(): void
     {
         $school = School::factory()->create([
-            'name' => 'Fake Academy'
+            'name' => 'Pambasang Mataas na Paraalan ng Albay',
+            'short_name' => 'PMNPNA',
         ]);
 
         $academicYears = [

--- a/src/database/seeders/StudentSeeder.php
+++ b/src/database/seeders/StudentSeeder.php
@@ -2,10 +2,14 @@
 
 namespace Database\Seeders;
 
+use App\Enums\RoleEnum;
+use App\Models\AcademicYear;
+use App\Models\Student;
 use App\Models\User;
 use App\Models\UserProfile;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
+use Spatie\Permission\Models\Role;
 
 class StudentSeeder extends Seeder
 {
@@ -24,10 +28,25 @@ class StudentSeeder extends Seeder
             'password' => Hash::make(self::STUDENT_EXAMPLE_PASSWORD),
         ]);
 
+        $student = Student::factory()->create([
+            'user_id' => $user->id,
+        ]);
+        $role = Role::where('name', RoleEnum::STUDENT)->first();
+        $user->assignRole($role);
+
         UserProfile::factory()->create([
             'user_id' => $user->id,
             'first_name' => self::STUDENT_FIRST_NAME,
             'last_name' => self::STUDENT_LAST_NAME,
         ]);
+
+        $this->generateStudentYears($student);
+    }
+
+    private function generateStudentYears($student): void
+    {
+        $academicYearIds = AcademicYear::pluck('id');
+
+        $student->academicYears()->syncWithoutDetaching($academicYearIds);
     }
 }


### PR DESCRIPTION
🎫 Ticket

feature: include school name and academic year in login response

📦 Packages

None

📝 Updates
- added school short name and academic year in successful login response
- flattern successful login response

```
{
    "message": "Authentication success",
    "data": {
        "id": 3,
        "login_type": "student",
        "login_id": "1",
        "email": "juandelacrud@example.com",
        "first_name": "Juan",
        "last_name": "De la Crud",
        "role": "student",
        "school_name": "PMNPNA",
        "academic_year": "2022-2023",
        "access_token": "token",
        "token_expiry": "2025-11-02T23:10:34.000000Z"
    }
}
```
🧪 Testing Steps

only checked response in postman